### PR TITLE
fix(ci): Correct poetry options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install poetry
 
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-dev --only main
+    && poetry install --only main
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process by modifying the Poetry installation command to always install production dependencies, regardless of the presence of a lockfile.

- Docker build process:
  * In the `Dockerfile`, removes the `--no-dev` flag from the `poetry install` command, ensuring that only main dependencies are installed, but allowing Poetry to create a lockfile if needed.