### PR TITLE
fix(ci): Build package with no root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install poetry
 
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry config virtualenvs.create false \
-    && poetry install --only main
+    && poetry install --only main --no-root
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
This pull request makes a minor change to the `Dockerfile` by modifying the Poetry install command. The update prevents the installation of the current package itself into the environment, which can speed up build times and avoid unnecessary dependencies.

* Changed the Poetry install command to use the `--no-root` flag, so that only dependencies specified in `pyproject.toml` are installed, not the root package itself (`Dockerfile`).