### PR TITLE
feat(ci): Enable manual workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,43 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to build from
+        required: true
+        default: main
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push nightly image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:nightly
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This pull request introduces a new nightly build workflow and updates the logic for tagging Docker images in the release workflow. The main focus is on improving automation for Docker image builds and ensuring nightly images are consistently published.

**New nightly build workflow:**

* Adds a `.github/workflows/nightly.yml` workflow that builds and pushes a nightly Docker image to GitHub Container Registry, with support for selecting the branch to build from via workflow dispatch.

**Release workflow improvements:**

* Updates the Docker image tagging logic in `.github/workflows/release.yml` to tag images as `latest` only when the workflow is triggered by a release event, making the condition more explicit and reliable.