### PR TITLE
feat(doc): Publish AI compliant documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs-site/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build static site
+        run: npx nuxt build --preset github_pages
+        env:
+          NUXT_APP_BASE_URL: /upki-ra/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/.output/public
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs-site/app.config.ts
+++ b/docs-site/app.config.ts
@@ -1,0 +1,41 @@
+export default defineAppConfig({
+  docus: {
+    title: "uPKI RA",
+    description:
+      "ACME v2 Registration Authority for private networks — RFC 8555 without Let's Encrypt.",
+    image: "/cover.png",
+    socials: {
+      github: "circle-rd/upki-ra",
+    },
+    github: {
+      dir: "docs-site/content",
+      branch: "main",
+      repo: "upki-ra",
+      owner: "circle-rd",
+      edit: true,
+    },
+    aside: {
+      level: 0,
+      collapsed: false,
+      exclude: [],
+    },
+    main: {
+      padded: true,
+      fluid: false,
+    },
+    header: {
+      logo: false,
+      showLinkIcon: true,
+      exclude: [],
+      fluid: false,
+    },
+    footer: {
+      iconLinks: [
+        {
+          href: "https://github.com/circle-rd/upki-ra",
+          icon: "simple-icons:github",
+        },
+      ],
+    },
+  },
+});

--- a/docs-site/content/docs/api/1.cli-reference.md
+++ b/docs-site/content/docs/api/1.cli-reference.md
@@ -1,0 +1,106 @@
+---
+title: CLI Reference
+description: Complete reference for the ra_server.py command-line interface.
+---
+
+# CLI Reference
+
+## Global flags
+
+These flags apply to all commands:
+
+| Flag               | Short | Default      | Env variable    | Description          |
+| ------------------ | ----- | ------------ | --------------- | -------------------- |
+| `--dir <path>`     | `-d`  | `~/.upki/ra` | `UPKI_DATA_DIR` | Data directory       |
+| `--ip <host>`      | `-i`  | `127.0.0.1`  | `UPKI_CA_HOST`  | CA ZMQ host          |
+| `--port <int>`     | `-p`  | `5000`       | `UPKI_CA_PORT`  | CA ZMQ port          |
+| `--web-ip <host>`  |       | `127.0.0.1`  | `UPKI_RA_HOST`  | RA bind address      |
+| `--web-port <int>` |       | `8000`       | `UPKI_RA_PORT`  | RA HTTP/HTTPS port   |
+| `--debug`          |       | `false`      | —               | Enable debug logging |
+
+## Commands
+
+### `init`
+
+Initialise the RA data directory structure. Idempotent.
+
+```bash
+python ra_server.py init
+```
+
+Prints the path to the data directory and the next steps.
+
+---
+
+### `register`
+
+Register the RA with the CA. Connects to CA port **5001**, presents the seed, and receives a signed certificate.
+
+```bash
+python ra_server.py register -s <seed> [-c <cn>]
+```
+
+| Option          | Short | Required | Description                    |
+| --------------- | ----- | -------- | ------------------------------ |
+| `--seed <seed>` | `-s`  | Yes      | CA registration seed           |
+| `--cn <name>`   | `-c`  | No       | RA Common Name (default: `RA`) |
+
+---
+
+### `listen`
+
+Start the RA HTTP/HTTPS server. The RA must already be registered.
+
+```bash
+python ra_server.py listen
+```
+
+Uses `--web-ip` / `--web-port` for the bind address. TLS is enabled when `UPKI_RA_TLS=true`.
+
+---
+
+### `start`
+
+Auto-bootstrap mode — the Docker default entrypoint.
+
+- If the RA is **not registered** (no `ra.crt` / `ra.key`): reads `UPKI_CA_SEED`, calls `register`, then starts the server.
+- If already registered: starts the server directly.
+
+```bash
+python ra_server.py start
+```
+
+Requires `UPKI_CA_SEED` environment variable on first boot.
+
+---
+
+### `crl`
+
+Fetch a new CRL from the CA and save it to `$UPKI_DATA_DIR/crl.pem`.
+
+```bash
+python ra_server.py crl
+```
+
+---
+
+## Environment variables
+
+| Variable        | CLI flag     | Description                                                       |
+| --------------- | ------------ | ----------------------------------------------------------------- |
+| `UPKI_DATA_DIR` | `-d`         | Data directory path                                               |
+| `UPKI_CA_HOST`  | `-i`         | CA ZMQ host                                                       |
+| `UPKI_CA_PORT`  | `-p`         | CA ZMQ port                                                       |
+| `UPKI_RA_HOST`  | `--web-ip`   | RA bind address                                                   |
+| `UPKI_RA_PORT`  | `--web-port` | RA HTTP/HTTPS port                                                |
+| `UPKI_CA_SEED`  | —            | CA registration seed (used by `start`)                            |
+| `UPKI_RA_CN`    | —            | RA Common Name for auto-registration (default: `RA`)              |
+| `UPKI_RA_TLS`   | —            | Enable HTTPS: `true` / `false` (default in Docker: `true`)        |
+| `UPKI_RA_SANS`  | —            | Comma-separated DNS SANs for the RA certificate (first boot only) |
+
+## Exit codes
+
+| Code | Meaning                                                          |
+| ---- | ---------------------------------------------------------------- |
+| `0`  | Success                                                          |
+| `1`  | Error (registration failure, server startup error, missing seed) |

--- a/docs-site/content/docs/api/2.acme-endpoints.md
+++ b/docs-site/content/docs/api/2.acme-endpoints.md
@@ -1,0 +1,197 @@
+---
+title: ACME Endpoints
+description: Complete list of ACME v2 (RFC 8555) endpoints exposed by uPKI RA.
+---
+
+# ACME Endpoints
+
+All ACME endpoints are under the root path and require JWS-signed requests (RFC 8555 §6) except the directory and nonce endpoints.
+
+## Base URL
+
+```
+https://<upki-ra-host>:8000
+```
+
+## Directory
+
+```
+GET /acme/directory
+```
+
+Returns the ACME directory object. Configure your ACME client's `caServer` to this URL.
+
+**Response:**
+
+```json
+{
+  "newNonce": "https://upki-ra:8000/acme/new-nonce",
+  "newAccount": "https://upki-ra:8000/acme/new-account",
+  "newOrder": "https://upki-ra:8000/acme/new-order",
+  "revokeCert": "https://upki-ra:8000/acme/revoke-cert",
+  "keyChange": "https://upki-ra:8000/acme/key-change",
+  "meta": {
+    "termsOfService": "https://upki-ra:8000/acme/terms",
+    "caaIdentities": []
+  }
+}
+```
+
+---
+
+## Nonce
+
+| Method | Path              | Status         |
+| ------ | ----------------- | -------------- |
+| `GET`  | `/acme/new-nonce` | 204 No Content |
+| `HEAD` | `/acme/new-nonce` | 200 OK         |
+
+Returns a fresh nonce in the `Replay-Nonce` response header. Every JWS-signed request must include a fresh nonce.
+
+---
+
+## Accounts
+
+| Method | Path                 | Description                     |
+| ------ | -------------------- | ------------------------------- |
+| `POST` | `/acme/new-account`  | Create or locate an account     |
+| `POST` | `/acme/account/{id}` | Update or deactivate an account |
+| `POST` | `/acme/key-change`   | Rotate the account key          |
+
+### Create account
+
+```
+POST /acme/new-account
+```
+
+**Request body** (JWS-signed, protected header contains `jwk`):
+
+```json
+{
+  "termsOfServiceAgreed": true,
+  "contact": ["mailto:admin@example.com"]
+}
+```
+
+**Response:** `201 Created` with account object and `Location` header.
+
+---
+
+## Orders
+
+| Method | Path                        | Description                              |
+| ------ | --------------------------- | ---------------------------------------- |
+| `POST` | `/acme/new-order`           | Create a new order                       |
+| `GET`  | `/acme/order/{id}`          | Get order status                         |
+| `POST` | `/acme/order/{id}`          | Update order (bump status)               |
+| `POST` | `/acme/order/{id}/finalize` | Submit CSR, trigger certificate issuance |
+
+### Create order
+
+```
+POST /acme/new-order
+```
+
+**Request body:**
+
+```json
+{
+  "identifiers": [{ "type": "dns", "value": "app.example.internal" }]
+}
+```
+
+**Response:** `201 Created` with order object including `authorizations` and `finalize` URLs.
+
+---
+
+## Authorizations
+
+| Method | Path               | Description                             |
+| ------ | ------------------ | --------------------------------------- |
+| `GET`  | `/acme/authz/{id}` | Get authorization status and challenges |
+| `POST` | `/acme/authz/{id}` | Deactivate an authorization             |
+
+---
+
+## Challenges
+
+| Method | Path                                    | Description                              |
+| ------ | --------------------------------------- | ---------------------------------------- |
+| `POST` | `/acme/challenge/{auth_id}/http-01`     | Trigger HTTP-01 challenge validation     |
+| `POST` | `/acme/challenge/{auth_id}/dns-01`      | Trigger DNS-01 challenge validation      |
+| `POST` | `/acme/challenge/{auth_id}/tls-alpn-01` | Trigger TLS-ALPN-01 challenge validation |
+| `GET`  | `/.well-known/acme-challenge/{token}`   | Serve HTTP-01 challenge token            |
+
+---
+
+## Certificate issuance
+
+```
+POST /acme/order/{id}/finalize
+```
+
+**Request body** (JWS-signed):
+
+```json
+{
+  "csr": "<base64url-encoded-DER-CSR>"
+}
+```
+
+The RA forwards the CSR to the CA over ZMQ, receives the signed certificate, and transitions the order to `valid` status.
+
+---
+
+## Certificate revocation
+
+```
+POST /acme/revoke-cert
+```
+
+**Request body** (JWS-signed with account key or certificate key):
+
+```json
+{
+  "certificate": "<base64url-encoded-DER-cert>",
+  "reason": 1
+}
+```
+
+RFC 5280 reason codes: 0 = unspecified, 1 = keyCompromise, 3 = affiliationChanged, 4 = superseded, 5 = cessationOfOperation.
+
+---
+
+## Public REST endpoints (no auth)
+
+These endpoints do not require ACME JWS signing.
+
+| Method | Path                             | Description                             |
+| ------ | -------------------------------- | --------------------------------------- |
+| `GET`  | `/api/v1/public/health`          | Health check                            |
+| `GET`  | `/api/v1/public/ca`              | Download CA certificate (PEM)           |
+| `GET`  | `/api/v1/public/crl`             | Download current CRL                    |
+| `GET`  | `/api/v1/public/profiles`        | List available certificate profiles     |
+| `GET`  | `/api/v1/public/profiles/{name}` | Get profile details                     |
+| `POST` | `/api/v1/public/certify`         | Request a node certificate (seed-based) |
+| `GET`  | `/api/v1/public/certs`           | List issued certificates                |
+| `GET`  | `/api/v1/public/certs/{cn}`      | Get certificate by CN                   |
+| `GET`  | `/api/v1/public/magic/{profile}` | Auto-generate certificate (magic mode)  |
+| `POST` | `/api/v1/public/ocsp`            | OCSP status check                       |
+
+---
+
+## Private REST endpoints (mTLS required)
+
+All endpoints under `/api/v1/private/` require a valid mTLS client certificate.
+
+| Method   | Path                           | Description               |
+| -------- | ------------------------------ | ------------------------- |
+| `GET`    | `/api/v1/private/nodes`        | List all registered nodes |
+| `POST`   | `/api/v1/private/nodes`        | Register a new node       |
+| `DELETE` | `/api/v1/private/nodes/{cn}`   | Delete a node             |
+| `GET`    | `/api/v1/private/admins`       | List admin nodes          |
+| `POST`   | `/api/v1/private/admins`       | Add admin node            |
+| `DELETE` | `/api/v1/private/admins/{dn}`  | Remove admin node         |
+| `POST`   | `/api/v1/private/crl/generate` | Trigger CRL regeneration  |
+| `GET`    | `/api/v1/private/config`       | Get RA configuration      |
+| `GET`    | `/api/v1/private/options`      | Get CA options            |

--- a/docs-site/content/docs/api/3.error-reference.md
+++ b/docs-site/content/docs/api/3.error-reference.md
@@ -1,0 +1,91 @@
+---
+title: Error Reference
+description: ACME and REST API error responses from uPKI RA.
+---
+
+# Error Reference
+
+## ACME error format (RFC 7807)
+
+All ACME errors follow RFC 7807 Problem Details:
+
+```json
+{
+  "type": "urn:ietf:params:acme:error:<code>",
+  "detail": "<human-readable message>",
+  "status": <http_status_code>
+}
+```
+
+## ACME error types
+
+| Type             | HTTP status | Cause                                                    |
+| ---------------- | ----------- | -------------------------------------------------------- |
+| `malformed`      | 400         | Request body is malformed or missing required fields     |
+| `unauthorized`   | 403         | JWS signature invalid or account not authorized          |
+| `rateLimited`    | 429         | Too many requests                                        |
+| `orderNotReady`  | 403         | Trying to finalize an order that is not in `ready` state |
+| `badCSR`         | 400         | CSR fields do not match the order identifiers            |
+| `badNonce`       | 400         | Nonce not found or already used                          |
+| `serverInternal` | 500         | Internal RA or CA error                                  |
+
+## REST API error format
+
+Non-ACME endpoints return:
+
+```json
+{
+  "status": "error",
+  "message": "<detail>"
+}
+```
+
+## Common errors and resolutions
+
+### `x509: certificate signed by unknown authority` (Traefik)
+
+Traefik's LEGO client cannot validate the RA's TLS certificate.
+
+**Resolution**: Inject `ca.crt` from the RA data volume into Traefik's trust store before startup. See [Traefik Integration](/docs/guides/traefik-integration).
+
+### `UPKI_CA_SEED is not set`
+
+The `start` command needs the seed for first-boot registration.
+
+**Resolution**: Set `UPKI_CA_SEED` in your environment or Docker Compose file.
+
+### `RA is not registered with CA`
+
+`listen` was called but no `ra.crt` / `ra.key` exist.
+
+**Resolution**: Run `register` first, or use `start` for auto-bootstrap.
+
+### `badNonce` on every request
+
+The client is reusing nonces.
+
+**Resolution**: Fetch a fresh nonce from `GET /acme/new-nonce` before every signed request.
+
+### `orderNotReady` on finalize
+
+The order's authorizations are not all in `valid` state.
+
+**Resolution**: Complete and validate all challenges before calling `finalize`.
+
+### CSR identifiers mismatch
+
+The identifiers in the CSR do not match the order identifiers.
+
+**Resolution**: Ensure the CSR's Common Name and/or SANs match exactly the `identifiers` submitted in the original `new-order` request.
+
+## Debug logging
+
+```bash
+# Show detailed RA logs
+docker logs upki-ra --follow
+
+# Enable debug mode (bare-metal)
+python ra_server.py listen --debug
+```
+
+The RA logs every ACME request, ZMQ call to the CA, and the CA's response.

--- a/docs-site/content/docs/community/1.contributing.md
+++ b/docs-site/content/docs/community/1.contributing.md
@@ -1,0 +1,96 @@
+---
+title: Contributing
+description: How to contribute to uPKI RA.
+---
+
+# Contributing to uPKI RA
+
+Thank you for your interest in contributing! Please read this guide before submitting patches.
+
+## Code of Conduct
+
+Be respectful and inclusive. Focus on what is best for the project. We will not tolerate harassment of any kind.
+
+## Getting started
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/upki-ra.git`
+3. **Create a branch**: `git checkout -b feature/my-feature`
+
+## Development environment
+
+```bash
+git clone https://github.com/circle-rd/upki-ra.git
+cd upki-ra
+
+python -m venv .venv
+source .venv/bin/activate
+
+pip install -e ".[dev]"
+
+# Verify
+pytest
+```
+
+### Pre-commit hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+## Coding standards
+
+| Rule            | Value                                                  |
+| --------------- | ------------------------------------------------------ |
+| Language        | English (code, comments, docs)                         |
+| File naming     | `snake_case.py`                                        |
+| Class naming    | `PascalCase`                                           |
+| Function naming | `snake_case`                                           |
+| Constants       | `UPPER_SNAKE_CASE`                                     |
+| Line length     | 120 characters                                         |
+| Type hints      | Required on all public functions                       |
+| Docstrings      | Google style, required on all public functions/classes |
+
+### Linter and formatter
+
+```bash
+# Lint
+ruff check upki_ra/ tests/
+
+# Format
+ruff format upki_ra/ tests/
+```
+
+## Testing
+
+All new code must include tests:
+
+```bash
+pytest                              # run all tests
+pytest tests/test_acme_api.py       # run a specific file
+pytest --cov=upki_ra                # with coverage
+```
+
+Minimum coverage target: **80%**.
+
+## Submitting changes
+
+1. Push your branch: `git push origin feature/my-feature`
+2. Open a Pull Request against `main`
+3. Fill in the PR template — describe what changes and why
+4. Ensure all CI checks pass (tests, lint)
+
+## Reporting issues
+
+Use the GitHub issue tracker. Include:
+
+- Python version
+- uPKI RA version
+- Steps to reproduce
+- Expected vs actual behaviour
+- Relevant log output
+
+## Documentation
+
+Documentation contributions are welcome. The docs site lives in `docs-site/`. Add or update Markdown files under `docs-site/content/docs/`.

--- a/docs-site/content/docs/concepts/1.architecture.md
+++ b/docs-site/content/docs/concepts/1.architecture.md
@@ -1,0 +1,88 @@
+---
+title: Architecture
+description: How uPKI RA is structured and how it bridges ACME clients with the uPKI CA.
+---
+
+# Architecture
+
+## Overview
+
+uPKI RA is a **FastAPI** application that speaks ACME v2 on one side and ZMQ on the other. It is stateful: all ACME objects (accounts, orders, authorizations, certificates) are stored in a local SQLite database.
+
+```
+┌──────────────────────────────────────────────────┐
+│                 uPKI RA process                   │
+│                                                   │
+│  ┌──────────────────────────────────────────┐    │
+│  │           FastAPI / uvicorn              │    │
+│  │                                          │    │
+│  │  /acme/*    (public — RFC 8555)          │    │
+│  │  /api/v1/*  (private — mTLS required)   │    │
+│  │  /api/client/* (client — mTLS required) │    │
+│  │  /api/public/* (public — no auth)       │    │
+│  └──────────────┬───────────────────────────┘    │
+│                 │                                 │
+│  ┌──────────────▼───────────────────────────┐    │
+│  │       RegistrationAuthority              │    │
+│  │  (ZMQ REQ client → CA port 5000)         │    │
+│  └──────────────────────────────────────────┘    │
+│                 │                                 │
+│  ┌──────────────▼───────────────────────────┐    │
+│  │         SQLiteStorage                    │    │
+│  │  accounts / orders / authorizations /    │    │
+│  │  challenges / certificates               │    │
+│  └──────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────┘
+        ▲                         │
+  ACME clients               ZMQ REQ
+  (Traefik, etc.)         CA port 5000
+```
+
+## Core components
+
+### `RegistrationAuthority`
+
+The main orchestrator (`upki_ra/registration_authority.py`). Initialises the ZMQ connection to the CA, manages bootstrapping, and exposes the ACME and admin operations to the route handlers.
+
+### Route modules
+
+| Module           | Path prefix       | Auth       | Description                          |
+| ---------------- | ----------------- | ---------- | ------------------------------------ |
+| `acme_api.py`    | `/acme/`          | JWS (ACME) | Full ACME v2 protocol                |
+| `public_api.py`  | `/api/v1/public/` | None       | Health check, CA cert download       |
+| `private_api.py` | `/api/v1/`        | mTLS       | Admin operations (issue, revoke…)    |
+| `client_api.py`  | `/api/client/`    | mTLS       | Client-facing certificate operations |
+
+### SQLite storage
+
+All ACME state lives in a single SQLite database file. Tables mirror ACME objects:
+
+- `accounts` — ACME accounts (JWK, contact, status)
+- `orders` — Certificate orders (identifiers, status, expiry)
+- `authorizations` — Per-identifier authorizations
+- `challenges` — HTTP-01/TLS-ALPN-01 challenges
+- `certificates` — Issued certificate PEM and metadata
+
+### ZMQ connector
+
+The RA maintains a persistent `zmq.REQ` socket to the CA on port 5000. All certificate operations are serialised as JSON and sent synchronously (request–reply).
+
+## Data directory layout
+
+```
+/data (UPKI_DATA_DIR)
+├── ra.config.yml       # RA configuration
+├── ra.crt              # RA TLS certificate
+├── ra.key              # RA TLS private key
+├── ca.crt              # CA certificate (downloaded from CA on bootstrap)
+└── acme.db             # SQLite ACME state
+```
+
+## Startup sequence
+
+1. Parse CLI flags / environment variables
+2. Connect ZMQ REQ socket to CA port 5000
+3. **Auto-bootstrap**: if no `ra.crt` found, register with CA port 5001 and obtain a certificate
+4. Configure uvicorn with the RA's TLS certificate (if `UPKI_RA_TLS=true`)
+5. Mount all route modules on the FastAPI app
+6. Start uvicorn event loop

--- a/docs-site/content/docs/concepts/2.acme-implementation.md
+++ b/docs-site/content/docs/concepts/2.acme-implementation.md
@@ -1,0 +1,95 @@
+---
+title: ACME Implementation
+description: How uPKI RA implements RFC 8555 (ACME v2) for private networks.
+---
+
+# ACME Implementation
+
+uPKI RA is a faithful implementation of [RFC 8555](https://tools.ietf.org/html/rfc8555) — the ACME v2 protocol. All standard objects (accounts, orders, authorizations, challenges, certificates) are supported.
+
+## Protocol flow
+
+```
+Client                          uPKI RA                    uPKI CA
+  │                                │                           │
+  │  GET /acme/directory           │                           │
+  │◄───────────────────────────────│                           │
+  │                                │                           │
+  │  POST /acme/new-account        │                           │
+  │───────────────────────────────►│                           │
+  │  ◄── 201 Created (account URL) │                           │
+  │                                │                           │
+  │  POST /acme/new-order          │                           │
+  │───────────────────────────────►│                           │
+  │  ◄── 201 Created (order URL)   │                           │
+  │                                │                           │
+  │  GET /acme/authz/{id}          │                           │
+  │───────────────────────────────►│                           │
+  │  ◄── 200 (challenge list)      │                           │
+  │                                │                           │
+  │  POST /acme/chall/{id}         │                           │
+  │───────────────────────────────►│                           │
+  │  ◄── 200 (challenge pending)   │                           │
+  │                                │                           │
+  │  [solve challenge]             │                           │
+  │                                │                           │
+  │  POST /acme/order/{id}/finalize│                           │
+  │  (with CSR)                    │                           │
+  │───────────────────────────────►│ ZMQ sign(csr, profile)   │
+  │                                │──────────────────────────►│
+  │                                │ ◄── {certificate, serial} │
+  │  ◄── 200 (order valid)         │                           │
+  │                                │                           │
+  │  POST /acme/cert/{id}          │                           │
+  │───────────────────────────────►│                           │
+  │  ◄── 200 (PEM chain)           │                           │
+```
+
+## Supported challenge types
+
+| Challenge     | Support    | Notes                                    |
+| ------------- | ---------- | ---------------------------------------- |
+| `tls-alpn-01` | ✅ Full    | Recommended for Traefik                  |
+| `http-01`     | ✅ Full    | Standard HTTP challenge                  |
+| `dns-01`      | ⚠️ Partial | Supported for cert-manager DNS providers |
+
+## Directory endpoint
+
+```
+GET /acme/directory
+```
+
+Returns the RFC 8555 directory object pointing to all ACME endpoints. Configure your ACME client's `caServer` to this URL.
+
+## Nonce management
+
+Every ACME request must include a fresh nonce. The RA issues nonces via:
+
+```
+HEAD /acme/new-nonce
+GET  /acme/new-nonce
+```
+
+## Account management
+
+| Endpoint             | Method | Description                  |
+| -------------------- | ------ | ---------------------------- |
+| `/acme/new-account`  | POST   | Create or lookup account     |
+| `/acme/account/{id}` | POST   | Update or deactivate account |
+| `/acme/key-change`   | POST   | Rotate account key           |
+
+## Certificate profile selection
+
+By default, the RA uses the `server` profile when requesting certificates from the CA. To use a different profile, include it in the order's `notBefore` / `notAfter` metadata or configure the RA's default profile (future feature).
+
+## Revocation
+
+```
+POST /acme/revoke-cert
+```
+
+Accepts a signed revocation request. The RA forwards the revocation to the CA via ZMQ and removes the certificate from its active set.
+
+## State synchronisation
+
+After every ACME operation that modifies CA state, the RA sends an `acme_sync_*` ZMQ message to the CA so the CA's storage stays consistent. This allows future RA instances to reconstruct state from the CA.

--- a/docs-site/content/docs/concepts/3.security-model.md
+++ b/docs-site/content/docs/concepts/3.security-model.md
@@ -1,0 +1,64 @@
+---
+title: Security Model
+description: How uPKI RA authenticates requests and protects the mTLS boundary.
+---
+
+# Security Model
+
+## Threat model
+
+uPKI RA sits between ACME clients (potentially untrusted) and the CA (highly trusted). Its security model ensures:
+
+1. Only authorised callers can request certificates
+2. The CA private key is never exposed to the RA
+3. Admin operations require mutual TLS authentication
+
+## Endpoint authentication
+
+| Route prefix       | Auth method               | Who can call                              |
+| ------------------ | ------------------------- | ----------------------------------------- |
+| `/acme/*`          | JWS (ACME account key)    | Any ACME client with a registered account |
+| `/api/v1/public/*` | None                      | Anyone (health check, CA cert download)   |
+| `/api/v1/*`        | mTLS (client certificate) | Admins with a CA-issued client cert       |
+| `/api/client/*`    | mTLS (client certificate) | Registered clients with a CA-issued cert  |
+
+## mTLS setup
+
+Admin and client endpoints require the caller to present a certificate signed by the same CA as the RA. The RA verifies the client certificate against its local `ca.crt` on every request.
+
+The RA's own TLS certificate is stored in `ra.crt` / `ra.key` inside the data directory. It is issued by the CA during bootstrap.
+
+## ACME account security
+
+ACME accounts are tied to a JWK (JSON Web Key). Every ACME request is signed with the account's private key and verified by the RA. The RA never stores account private keys — only the public JWK.
+
+## Auto-bootstrap security
+
+The bootstrap process uses CA port **5001** (RA registration) with the shared CA seed. This is intentionally a one-time operation:
+
+::callout{type="warning"}
+Set `UPKI_RA_SANS` **before** the first `start`. The RA's certificate SAN list cannot change after bootstrap without re-registration. Ensure all hostnames clients will use to reach the RA are listed.
+::
+
+## TLS configuration
+
+When `UPKI_RA_TLS=true` (default in Docker), uvicorn serves HTTPS using the RA's own certificate. Clients must:
+
+1. Trust the CA certificate (`ca.crt` from `/api/v1/public/ca`)
+2. Present a valid client certificate for protected endpoints
+
+## Seed security
+
+The `UPKI_CA_SEED` environment variable is used only once (during bootstrap) and is not stored on disk by the RA.
+
+::callout{type="danger"}
+Do not hard-code `UPKI_CA_SEED` in Docker Compose files committed to source control. Use Docker secrets, environment files outside the repo, or a secrets manager.
+::
+
+## Network exposure
+
+| Port | Exposed to                | Rationale        |
+| ---- | ------------------------- | ---------------- |
+| 8000 | ACME clients, admin tools | ACME + admin API |
+
+The RA does not need to be publicly internet-accessible. It only needs to be reachable by your ACME clients (Traefik, cert-manager, etc.) within your private network.

--- a/docs-site/content/docs/getting-started/1.introduction.md
+++ b/docs-site/content/docs/getting-started/1.introduction.md
@@ -1,0 +1,50 @@
+---
+title: Introduction
+description: What is uPKI RA and how does it fit in the uPKI ecosystem?
+---
+
+# Introduction
+
+**uPKI RA** is a fully compliant ACME v2 Registration Authority (RFC 8555) written in Python. It acts as the bridge between ACME clients (Traefik, cert-manager, acme.sh…) and a [uPKI CA](https://github.com/circle-rd/upki-ca) instance, enabling fully private TLS certificate automation without any internet dependency.
+
+## What it does
+
+- Implements the complete ACME v2 protocol — new-account, new-order, authorization, challenge, finalize, certificate download, revocation
+- Translates ACME requests into ZMQ calls on the uPKI CA
+- Manages its own state in SQLite (accounts, orders, authorizations, certificates)
+- Protects admin endpoints with mutual TLS (mTLS)
+- Auto-bootstraps its own certificate on first start
+
+## What it does NOT do
+
+- It does not issue certificates itself — it delegates all signing to uPKI CA
+- It does not replace Let's Encrypt for public-facing internet certificates
+- It does not support legacy ACME v1
+
+## Where it fits
+
+```
+[Traefik / cert-manager / acme.sh]
+        │  ACME v2 (HTTPS)
+        ▼
+  [uPKI RA :8000]  ─── ZMQ :5000 ───►  [uPKI CA]
+        │  on first start
+        └─── ZMQ :5001 ──► CA registration
+```
+
+## Related projects
+
+| Project                                           | Role                      |
+| ------------------------------------------------- | ------------------------- |
+| [upki-ca](https://github.com/circle-rd/upki-ca)   | The Certificate Authority |
+| [upki-ra](https://github.com/circle-rd/upki-ra)   | This project — ACME v2 RA |
+| [upki-cli](https://github.com/circle-rd/upki-cli) | Command-line admin tool   |
+
+## Technology stack
+
+- **Python** 3.12+
+- **FastAPI** + **uvicorn** — ACME HTTP server
+- **pyzmq** — ZMQ client to uPKI CA
+- **SQLite** — ACME state persistence
+- **cryptography** — JWS verification, CSR handling
+- **Click** — CLI framework

--- a/docs-site/content/docs/getting-started/2.installation.md
+++ b/docs-site/content/docs/getting-started/2.installation.md
@@ -1,0 +1,65 @@
+---
+title: Installation
+description: How to install uPKI RA from source, pip, or Docker.
+---
+
+# Installation
+
+## Requirements
+
+- Python **3.12** or higher
+- `pip` / `pipx` / [Poetry](https://python-poetry.org/) 1.8+
+- A running [uPKI CA](https://github.com/circle-rd/upki-ca) instance reachable on ZMQ ports 5000 and 5001
+
+## From PyPI
+
+```bash
+pip install upki-ra
+```
+
+Or with [pipx](https://pipx.pypa.io/) to keep it isolated:
+
+```bash
+pipx install upki-ra
+```
+
+## From source (development)
+
+```bash
+git clone https://github.com/circle-rd/upki-ra.git
+cd upki-ra
+
+# Install with Poetry
+poetry install
+
+# Or with pip in editable mode
+pip install -e ".[dev]"
+```
+
+## Docker
+
+```bash
+docker pull ghcr.io/circle-rd/upki-ra:latest
+```
+
+Or build locally:
+
+```bash
+docker build -t upki-ra .
+```
+
+## Verify installation
+
+```bash
+upki-ra --version
+```
+
+Expected output:
+
+```
+upki-ra, version X.Y.Z
+```
+
+## Next step
+
+Continue to the [Quick Start](/docs/getting-started/quick-start) guide to initialise and start receiving ACME requests.

--- a/docs-site/content/docs/getting-started/3.quick-start.md
+++ b/docs-site/content/docs/getting-started/3.quick-start.md
@@ -1,0 +1,115 @@
+---
+title: Quick Start
+description: Initialise the RA, register with your CA, and serve your first ACME certificate.
+---
+
+# Quick Start
+
+This guide walks you through the complete RA lifecycle: initialise, register with the CA, and start serving ACME requests.
+
+::callout{type="warning"}
+You need a running **uPKI CA** instance before proceeding. See the [CA quick start](https://github.com/circle-rd/upki-ca) first.
+::
+
+## Step 1 — Initialise the RA
+
+```bash
+upki-ra init \
+  --data-dir /opt/upki/ra \
+  --ca-host 127.0.0.1
+```
+
+This creates the RA's local data directory and configuration.
+
+## Step 2 — Register with the CA
+
+```bash
+upki-ra register \
+  --data-dir /opt/upki/ra \
+  --ca-host 127.0.0.1 \
+  --seed "the-ca-registration-seed"
+```
+
+The RA connects to CA port **5001** and issues itself a server certificate.
+
+## Step 3 — Start the RA daemon (with auto-bootstrap)
+
+```bash
+upki-ra start \
+  --data-dir /opt/upki/ra \
+  --ca-host 127.0.0.1 \
+  --tls
+```
+
+::callout{type="info"}
+On the very first `start`, the RA automatically bootstraps — it registers itself with the CA if not already done, obtains its TLS certificate, and then begins serving ACME requests.
+::
+
+The RA is now available at `https://localhost:8000`.
+
+## Step 4 — Point an ACME client at the RA
+
+### Traefik
+
+```yaml
+# traefik.yml
+certificatesResolvers:
+  upki:
+    acme:
+      caServer: "https://upki-ra:8000/acme/directory"
+      storage: /acme/acme.json
+      tlsChallenge: {}
+```
+
+### acme.sh
+
+```bash
+acme.sh --server https://upki-ra:8000/acme/directory \
+        --issue -d server.example.internal \
+        --standalone
+```
+
+## Step 5 — Generate the CRL (optional)
+
+```bash
+upki-ra crl --data-dir /opt/upki/ra
+```
+
+## Docker compose (recommended)
+
+```yaml
+services:
+  upki-ca:
+    image: ghcr.io/circle-rd/upki-ca:latest
+    environment:
+      UPKI_CA_SEED: "${UPKI_CA_SEED}"
+    volumes:
+      - ca-data:/data
+    ports:
+      - "5000:5000"
+      - "5001:5001"
+
+  upki-ra:
+    image: ghcr.io/circle-rd/upki-ra:latest
+    environment:
+      UPKI_CA_HOST: upki-ca
+      UPKI_CA_SEED: "${UPKI_CA_SEED}"
+      UPKI_RA_TLS: "true"
+      UPKI_RA_SANS: "upki-ra,ra.example.internal"
+    volumes:
+      - ra-data:/data
+    ports:
+      - "8000:8000"
+    depends_on:
+      - upki-ca
+
+volumes:
+  ca-data:
+  ra-data:
+```
+
+## Next steps
+
+- [Traefik integration guide](/docs/guides/traefik-integration)
+- [Environment variables reference](/docs/api/cli-reference)
+- [ACME endpoints](/docs/api/acme-endpoints)

--- a/docs-site/content/docs/guides/1.docker-deployment.md
+++ b/docs-site/content/docs/guides/1.docker-deployment.md
@@ -1,0 +1,136 @@
+---
+title: Docker Deployment
+description: Run uPKI RA in Docker or Docker Compose with production-ready settings.
+---
+
+# Docker Deployment
+
+## Environment variables
+
+The Docker image ships with these defaults:
+
+| Variable        | Image default | Description                                         |
+| --------------- | ------------- | --------------------------------------------------- |
+| `UPKI_DATA_DIR` | `/data`       | Data directory path                                 |
+| `UPKI_CA_HOST`  | `upki-ca`     | CA hostname (ZMQ connection)                        |
+| `UPKI_CA_PORT`  | `5000`        | CA ZMQ port                                         |
+| `UPKI_RA_HOST`  | `0.0.0.0`     | RA bind address                                     |
+| `UPKI_RA_PORT`  | `8000`        | RA HTTP/HTTPS port                                  |
+| `UPKI_RA_TLS`   | `true`        | Enable HTTPS (uses `ra.crt`/`ra.key`)               |
+| `UPKI_RA_SANS`  | `upki-ra`     | SANs for the RA's own certificate (first boot only) |
+
+## Single container
+
+```bash
+docker run -d \
+  --name upki-ra \
+  -p 8000:8000 \
+  -e UPKI_CA_HOST=upki-ca \
+  -e UPKI_CA_SEED="${PKI_SEED}" \
+  -e UPKI_RA_SANS="upki-ra,ra.example.internal" \
+  -v upki-ra-data:/data \
+  ghcr.io/circle-rd/upki-ra:latest
+```
+
+## Docker Compose (complete stack)
+
+```yaml
+# docker-compose.yml
+services:
+  upki-ca:
+    image: ghcr.io/circle-rd/upki-ca:latest
+    restart: unless-stopped
+    environment:
+      UPKI_DATA_DIR: /data
+      UPKI_CA_SEED: ${PKI_SEED}
+      UPKI_CA_HOST: 0.0.0.0
+    volumes:
+      - upki-ca-data:/data
+    networks:
+      - pki-net
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >
+          python -c "import socket; s=socket.socket(); s.settimeout(2);
+          s.connect(('127.0.0.1', 5000)); s.close()"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  upki-ra:
+    image: ghcr.io/circle-rd/upki-ra:latest
+    restart: unless-stopped
+    depends_on:
+      upki-ca:
+        condition: service_healthy
+    environment:
+      UPKI_DATA_DIR: /data
+      UPKI_CA_HOST: upki-ca
+      UPKI_CA_SEED: ${PKI_SEED}
+      UPKI_RA_TLS: "true"
+      UPKI_RA_SANS: "upki-ra,${DOMAIN}"
+    volumes:
+      - upki-ra-data:/data
+    ports:
+      - "8000:8000"
+    networks:
+      - pki-net
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >
+          python -c "
+          import os, urllib.request, ssl
+          tls = os.getenv('UPKI_RA_TLS','true').lower() not in ('false','0','no')
+          ctx = ssl.create_default_context() if tls else None
+          if ctx: ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
+          urllib.request.urlopen(
+            ('https' if tls else 'http')+'://localhost:8000/api/v1/public/health',
+            context=ctx, timeout=5)
+          "
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  upki-ca-data:
+  upki-ra-data:
+
+networks:
+  pki-net:
+    internal: true
+```
+
+`.env`:
+
+```bash
+PKI_SEED=your-strong-random-seed-here
+DOMAIN=ra.example.internal
+```
+
+## UPKI_RA_SANS — important caveat
+
+::callout{type="warning"}
+`UPKI_RA_SANS` is consumed **only on the first boot** when the RA registers with the CA. Changing it afterwards has no effect until the RA certificate is re-issued (re-registration).
+
+Always set all expected hostnames (Docker service name, FQDN, IP) **before** the first `start`.
+::
+
+Example:
+
+```bash
+UPKI_RA_SANS=upki-ra,ra.example.internal,192.168.1.5
+```
+
+## Data persistence
+
+Mount `UPKI_DATA_DIR` as a named volume. This directory contains:
+
+- `ra.crt` / `ra.key` — RA TLS certificate and key
+- `ca.crt` — downloaded CA certificate
+- `acme.db` — SQLite ACME state
+
+If the volume is lost, the RA will re-bootstrap on next start (generating a new certificate).

--- a/docs-site/content/docs/guides/2.traefik-integration.md
+++ b/docs-site/content/docs/guides/2.traefik-integration.md
@@ -1,0 +1,280 @@
+---
+title: Traefik Integration
+description: Use uPKI RA as a drop-in ACME v2 provider for Traefik v3.
+---
+
+# Traefik Integration
+
+uPKI is designed as a drop-in replacement for Let's Encrypt in environments where internet access is unavailable — private infrastructure, air-gapped networks, corporate LANs. Traefik's built-in ACME client (LEGO) connects directly to uPKI RA as a custom CA server.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "Docker network"
+        direction TB
+
+        subgraph "Services"
+            SVC[your-app<br/>labels: traefik.enable=true]
+        end
+
+        subgraph "Traefik v3"
+            T_PROXY[Reverse Proxy<br/>:80 / :443]
+            LEGO[LEGO ACME client]
+            TRUST[Alpine trust store<br/>+ upki-ca.crt]
+        end
+
+        subgraph "uPKI RA"
+            RA[ACME v2 + REST API<br/>:8000 HTTPS]
+        end
+
+        subgraph "uPKI CA"
+            CA[Certificate Authority<br/>:5000 ZMQ<br/>:5001 ZMQ register]
+        end
+    end
+
+    Browser -->|HTTPS :443| T_PROXY
+    T_PROXY -->|route| SVC
+    LEGO -->|ACME order HTTPS| RA
+    RA -->|CSR sign ZMQ| CA
+    TRUST -.->|inject ca.crt| LEGO
+```
+
+## Why uPKI instead of Let's Encrypt?
+
+| Scenario                        | Let's Encrypt | uPKI                |
+| ------------------------------- | ------------- | ------------------- |
+| Public internet access required | Yes           | **No**              |
+| Wildcard certificates           | DNS-01 only   | HTTP-01 or DNS-01   |
+| Air-gapped / private networks   | Not possible  | **Fully supported** |
+| Custom CA hierarchy             | No            | Yes                 |
+| Automated renewal (ACME)        | Yes           | **Yes**             |
+
+## How it works
+
+1. **RA serves HTTPS** — `UPKI_RA_TLS=true` (default in the Docker image) makes uvicorn use the RA's own certificate (`ra.crt` / `ra.key`).
+2. **Traefik trusts the internal CA** — the RA certificate is signed by uPKI CA. Before starting, Traefik's Alpine entrypoint injects `ca.crt` from the RA data volume into the system trust store so LEGO can validate the RA's TLS certificate.
+3. **LEGO sends an ACME order** — Traefik resolves `https://upki-ra:8000/acme/directory` and follows the RFC 8555 protocol.
+4. **RA validates the challenge and signs** — HTTP-01 challenges are validated directly; DNS-01 challenges use dnspython. The RA forwards the CSR to the CA over ZMQ.
+5. **Certificate returned to LEGO** — stored in `acme.json`, served to clients on port 443.
+
+## Prerequisites
+
+- Docker Compose v2
+- `upki-ca` and `upki-ra` on the same Docker network as Traefik
+- Port 80 reachable by the RA for HTTP-01 challenge validation
+- `PKI_SEED` environment variable (generated at CA `init` time)
+
+## Quick start
+
+### 1. traefik.yml
+
+```yaml
+api:
+  insecure: true
+
+log:
+  level: INFO
+
+providers:
+  docker:
+    exposedByDefault: false
+    network: demo-net
+
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+certificatesResolvers:
+  upki:
+    acme:
+      caServer: https://upki-ra:8000/acme/directory
+      storage: /acme/acme.json
+      httpChallenge:
+        entryPoint: web
+```
+
+### 2. docker-compose.yml
+
+```yaml
+services:
+  upki-ca:
+    image: ghcr.io/circle-rd/upki-ca:latest
+    restart: unless-stopped
+    environment:
+      UPKI_DATA_DIR: /data
+      UPKI_CA_SEED: ${PKI_SEED}
+    volumes:
+      - upki-ca-data:/data
+    networks:
+      - demo-net
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >
+          python -c "import socket; s=socket.socket(); s.settimeout(2);
+          s.connect(('127.0.0.1', 5000)); s.close()"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  upki-ra:
+    image: ghcr.io/circle-rd/upki-ra:latest
+    restart: unless-stopped
+    depends_on:
+      upki-ca:
+        condition: service_healthy
+    environment:
+      UPKI_DATA_DIR: /data
+      UPKI_CA_HOST: upki-ca
+      UPKI_CA_SEED: ${PKI_SEED}
+      UPKI_RA_HOST: 0.0.0.0
+    volumes:
+      - upki-ra-data:/data
+    networks:
+      - demo-net
+
+  traefik:
+    image: traefik:v3
+    restart: unless-stopped
+    depends_on:
+      upki-ra:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        cp /ra-data/ca.crt /usr/local/share/ca-certificates/upki-ca.crt
+        update-ca-certificates
+        exec traefik
+    environment:
+      TRAEFIK_CERTIFICATESRESOLVERS_UPKI_ACME_EMAIL: ${ADMIN_EMAIL}
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - acme:/acme
+      - ./traefik.yml:/etc/traefik/traefik.yml:ro
+      - upki-ra-data:/ra-data:ro
+    networks:
+      - demo-net
+
+  your-app:
+    image: your-app:latest
+    networks:
+      - demo-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.your-app.rule=Host(`app.${DOMAIN}`)"
+      - "traefik.http.routers.your-app.entrypoints=websecure"
+      - "traefik.http.routers.your-app.tls=true"
+      - "traefik.http.routers.your-app.tls.certresolver=upki"
+      - "traefik.http.services.your-app.loadbalancer.server.port=3000"
+
+volumes:
+  upki-ca-data:
+  upki-ra-data:
+  acme:
+
+networks:
+  demo-net:
+```
+
+### 3. .env
+
+```bash
+PKI_SEED=<generated-by-upki-ca-init>
+ADMIN_EMAIL=admin@example.com
+DOMAIN=example.internal
+```
+
+## DNS resolution
+
+### Docker internal DNS (default)
+
+Docker's embedded DNS resolves container names automatically within a Compose network. This is sufficient for `upki-ra` and `upki-ca` to find each other.
+
+For `Host(`app.${DOMAIN}`)` labels, the domain must resolve to the Docker host. Options:
+
+- **Static `/etc/hosts` entries** — simple but manual
+- **Local DNS server** — e.g. `ghcr.io/circle-rd/dns-resolver` which resolves `*.DOMAIN` to the host IP
+
+### DNS-01 challenge
+
+Use DNS-01 when port 80 is unavailable or for wildcard certificates:
+
+```yaml
+# traefik.yml
+certificatesResolvers:
+  upki:
+    acme:
+      caServer: https://upki-ra:8000/acme/directory
+      storage: /acme/acme.json
+      dnsChallenge:
+        provider: <your-dns-provider>
+```
+
+## Kubernetes with cert-manager
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: upki-issuer
+spec:
+  acme:
+    server: https://upki-ra.upki.svc.cluster.local:8000/acme/directory
+    email: admin@example.com
+    privateKeySecretRef:
+      name: upki-account-key
+    caBundle: <base64-encoded-ca.crt>
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik
+```
+
+## Traefik labels reference
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.<name>.rule=Host(`<hostname>`)"
+  - "traefik.http.routers.<name>.entrypoints=websecure"
+  - "traefik.http.routers.<name>.tls=true"
+  - "traefik.http.routers.<name>.tls.certresolver=upki"
+  - "traefik.http.services.<name>.loadbalancer.server.port=<port>"
+```
+
+## Troubleshooting
+
+### `x509: certificate signed by unknown authority`
+
+Traefik cannot validate the RA's TLS certificate. Ensure:
+
+- The `upki-ra-data` volume is mounted at `/ra-data` in Traefik.
+- The entrypoint copies `ca.crt` before starting Traefik.
+- The RA is `healthy` and `ca.crt` is present in the data volume.
+
+### HTTP-01 challenge fails / timeout
+
+- Verify port 80 is forwarded to Traefik.
+- Check the `web` entrypoint is configured in `traefik.yml`.
+- The RA must reach the challenged domain on port 80.
+
+### `UPKI_CA_SEED is not set`
+
+The `start` command requires `UPKI_CA_SEED` on first boot. Verify it is set and matches the seed printed by `ca_server.py init`.
+
+### `UPKI_RA_SANS` has no effect
+
+`UPKI_RA_SANS` is read only during initial registration. To change the SANs, delete `ra.crt` and `ra.key` from the data volume and restart the container.
+
+### Certificate not renewed
+
+Traefik/LEGO renews certificates at 30 days before expiry. The default `server` profile issues 60-day certificates, so renewal occurs around day 30. Check `acme.json` and Traefik logs.

--- a/docs-site/content/docs/guides/3.mtls-admin-setup.md
+++ b/docs-site/content/docs/guides/3.mtls-admin-setup.md
@@ -1,0 +1,133 @@
+---
+title: mTLS Admin Setup
+description: How to configure mutual TLS for the RA's admin and client endpoints.
+---
+
+# mTLS Admin Setup
+
+The RA protects its admin (`/api/v1/*`) and client (`/api/client/*`) endpoints with **mutual TLS (mTLS)**. Both the RA and the caller must present valid certificates signed by the same CA.
+
+## Overview
+
+```
+Admin tool / uPKI CLI
+        │
+        │  HTTPS (client cert = admin cert, signed by uPKI CA)
+        ▼
+  uPKI RA :8000
+        │  verifies client cert against ca.crt
+        │  (rejects if not signed by the same CA)
+```
+
+## Step 1 — Obtain an admin client certificate
+
+Using [uPKI CLI](https://github.com/circle-rd/upki-cli):
+
+```bash
+upki-cli generate \
+  --host 127.0.0.1 \
+  --cn "admin.example.internal" \
+  --profile admin
+```
+
+This issues a certificate with `clientAuth` extended key usage, signed by the CA.
+
+Alternatively, request it via ZMQ directly:
+
+```json
+{
+  "TASK": "generate",
+  "params": {
+    "cn": "admin.example.internal",
+    "profile": "admin"
+  }
+}
+```
+
+## Step 2 — Configure the HTTP client
+
+For `curl`:
+
+```bash
+curl --cert admin.crt \
+     --key admin.key \
+     --cacert ca.crt \
+     https://upki-ra:8000/api/v1/health
+```
+
+For Python (httpx / requests):
+
+```python
+import httpx
+
+client = httpx.Client(
+    cert=("admin.crt", "admin.key"),
+    verify="ca.crt"
+)
+response = client.get("https://upki-ra:8000/api/v1/health")
+```
+
+## Step 3 — Verify access
+
+```bash
+# Should return 200 OK
+curl -s \
+  --cert admin.crt \
+  --key admin.key \
+  --cacert ca.crt \
+  https://upki-ra:8000/api/v1/health
+```
+
+Without a valid client certificate:
+
+```bash
+curl --cacert ca.crt https://upki-ra:8000/api/v1/health
+# → 403 Forbidden or TLS handshake error
+```
+
+## Certificate profiles
+
+| Endpoint type | Recommended profile | Extended Key Usage         |
+| ------------- | ------------------- | -------------------------- |
+| Admin API     | `admin`             | `clientAuth`               |
+| Client API    | `user` or `laptop`  | `clientAuth`               |
+| RA itself     | `ra` (auto-issued)  | `serverAuth`, `clientAuth` |
+
+## Revoking admin access
+
+To revoke an admin certificate:
+
+```json
+{
+  "TASK": "revoke",
+  "params": {
+    "dn": "/CN=admin.example.internal",
+    "reason": "cessationOfOperation"
+  }
+}
+```
+
+Then regenerate the CRL:
+
+```json
+{
+  "TASK": "generate_crl",
+  "params": {}
+}
+```
+
+The RA reads the CRL on startup and on certificate validation — revoked certificates are rejected immediately after the CRL is updated.
+
+## Docker compose with mTLS admin
+
+If running the RA behind Traefik and wanting to protect admin routes further, add a Traefik middleware for mTLS passthrough:
+
+```yaml
+labels:
+  - "traefik.http.routers.upki-ra-admin.rule=Host(`ra.example.internal`) && PathPrefix(`/api/v1`)"
+  - "traefik.http.routers.upki-ra-admin.tls=true"
+  - "traefik.http.routers.upki-ra-admin.tls.certresolver=upki"
+  - "traefik.http.routers.upki-ra-admin.middlewares=strip-admin"
+```
+
+The RA itself handles mTLS verification for the `/api/v1/*` routes — Traefik only needs to forward the client certificate headers.

--- a/docs-site/content/index.md
+++ b/docs-site/content/index.md
@@ -1,0 +1,122 @@
+---
+title: uPKI RA
+navigation: false
+layout: page
+---
+
+## ::hero
+
+announcement:
+title: 'Traefik native integration'
+icon: '🚀'
+to: /docs/guides/traefik-integration
+actions:
+
+- name: Get Started
+  to: /docs/getting-started/introduction
+- name: GitHub
+  variant: ghost
+  to: https://github.com/circle-rd/upki-ra
+  leftIcon: 'lucide:github'
+
+---
+
+#title
+ACME v2 for\nprivate networks.
+
+#description
+uPKI RA is a fully compliant **ACME v2 Registration Authority** (RFC 8555) that connects your internal infrastructure to a self-hosted CA. Use Traefik, cert-manager, or any ACME client — no Let's Encrypt required.
+::
+
+::card-grid
+#title
+Why uPKI RA?
+
+#root
+:ellipsis
+
+#default
+::card
+
+---
+
+icon: lucide:shield-check
+
+---
+
+#title
+RFC 8555 compliant
+#description
+Full ACME v2 implementation — new-account, new-order, challenges, certificate issuance and revocation.
+::
+
+::card
+
+---
+
+icon: lucide:rocket
+
+---
+
+#title
+Auto-bootstrap
+#description
+First `start` automatically registers the RA with the CA and issues its own mTLS certificate.
+::
+
+::card
+
+---
+
+icon: lucide:lock
+
+---
+
+#title
+mTLS by default
+#description
+Mutual TLS protects all admin and client endpoints. Docker image ships with TLS enabled by default.
+::
+
+::card
+
+---
+
+icon: lucide:layers
+
+---
+
+#title
+Traefik native
+#description
+Works out of the box as a Traefik ACME provider. Point `caServer` at the RA and you're done.
+::
+
+::card
+
+---
+
+icon: lucide:wifi-off
+
+---
+
+#title
+Air-gapped friendly
+#description
+Zero internet dependency. Deploy behind a firewall, in a DMZ, or in a fully isolated network.
+::
+
+::card
+
+---
+
+icon: lucide:database
+
+---
+
+#title
+SQLite state
+#description
+ACME state (accounts, orders, authorizations) stored in SQLite. Simple, reliable, zero operational overhead.
+::
+::

--- a/docs-site/nuxt.config.ts
+++ b/docs-site/nuxt.config.ts
@@ -1,0 +1,2 @@
+extends:
+  - '@nuxt-themes/docus'

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "upki-ra-docs",
+    "version": "1.0.0",
+    "private": true,
+    "scripts": {
+        "dev": "nuxt dev",
+        "build": "nuxt build",
+        "generate": "nuxt generate",
+        "preview": "nuxt preview"
+    },
+    "devDependencies": {
+        "nuxt": "^3.13.0"
+    },
+    "dependencies": {
+        "@nuxt-themes/docus": "^1.15.0"
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the `uPKI RA` project by adding a docs site and several detailed reference documents. It also sets up an automated workflow for building and deploying the documentation to GitHub Pages. The changes are organized into three main themes: documentation site infrastructure, API and CLI documentation, and contribution guidelines.

**Documentation site infrastructure:**

* Added a GitHub Actions workflow (`.github/workflows/docs.yml`) to automatically build and deploy the documentation site from the `docs-site` directory to GitHub Pages on each push to `main`.
* Created a Nuxt/Docus site configuration in `docs-site/app.config.ts`, specifying the site title, description, GitHub integration, layout, and footer links.

**API and CLI documentation:**

* Added a detailed CLI reference (`docs-site/content/docs/api/1.cli-reference.md`) covering all global flags, commands, environment variables, and exit codes for `ra_server.py`.
* Documented all ACME v2 endpoints, public/private REST endpoints, request/response formats, and workflows in `docs-site/content/docs/api/2.acme-endpoints.md`.
* Provided a reference for error formats and common issues for both ACME and REST APIs in `docs-site/content/docs/api/3.error-reference.md`.
* Added an architecture overview (`docs-site/content/docs/concepts/1.architecture.md`) describing the internal structure, data flow, and startup sequence of uPKI RA.

**Contribution guidelines:**

* Added a contributing guide (`docs-site/content/docs/community/1.contributing.md`) with instructions for setting up a development environment, coding standards, testing, submitting changes, and reporting issues.